### PR TITLE
Include series in harvest API (and improve lots of other stuff)

### DIFF
--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/Series.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/Series.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.series.api;
+
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+
+import java.util.Date;
+
+
+/**
+ * An Opencast series.
+ */
+public class Series {
+  /** The ID of this series */
+  private String id;
+
+  /** The organization this series belongs to */
+  private String organization;
+
+  /** Serialized dublin core metadata catalogue */
+  private DublinCoreCatalog dublinCore;
+
+  /** Serialized access control lists */
+  private String accessControl;
+
+  /** Date of the last time anything about this series was modified */
+  private Date modifiedDate;
+
+  /**
+   * Date of the last time this series was deleted, or {@code null} if it is not currently deleted.
+   */
+  private Date deletionDate;
+
+
+  public String getId() {
+    return this.id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getOrganization() {
+    return this.organization;
+  }
+
+  public void setOrganization(String organization) {
+    this.organization = organization;
+  }
+
+  public DublinCoreCatalog getDublinCore() {
+    return this.dublinCore;
+  }
+
+  public void setDublinCore(DublinCoreCatalog dublinCore) {
+    this.dublinCore = dublinCore;
+  }
+
+  public String getAccessControl() {
+    return this.accessControl;
+  }
+
+  public void setAccessControl(String accessControl) {
+    this.accessControl = accessControl;
+  }
+
+  public Date getModifiedDate() {
+    return this.modifiedDate;
+  }
+
+  public void setModifiedDate(Date modifiedDate) {
+    this.modifiedDate = modifiedDate;
+  }
+
+  public Date getDeletionDate() {
+    return this.deletionDate;
+  }
+
+  public void setDeletionDate(Date deletionDate) {
+    this.deletionDate = deletionDate;
+  }
+
+
+  /** Returns whether or not this series is currently deleted. */
+  public boolean isDeleted() {
+    return deletionDate != null;
+  }
+}

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
@@ -29,7 +29,10 @@ import org.opencastproject.util.NotFoundException;
 
 import com.entwinemedia.fn.data.Opt;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Series service API for creating, removing and searching over series.
@@ -150,6 +153,16 @@ public interface SeriesService {
    *           if query could not be performed
    */
   DublinCoreCatalogList getSeries(SeriesQuery query) throws SeriesException, UnauthorizedException;
+
+
+  /**
+   * Returns all series (including deleted ones!) that have been modified in the
+   * given date range {@code from} (inclusive) -- {@code to} (exclusive). At
+   * most {@code limit} many series are returned. ACLs/permissions are NOT
+   * checked as this is only intended to be used in an administrative context.
+   */
+  List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesException;
 
   /**
    * Returns a map of series Id to title of all series the user can access

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
@@ -24,14 +24,17 @@ package org.opencastproject.series.impl;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.impl.persistence.SeriesEntity;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
 
 import com.entwinemedia.fn.data.Opt;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * API that defines persistent storage of series.
@@ -104,6 +107,15 @@ public interface SeriesServiceDatabase {
    *           if exception occurs
    */
   List<SeriesEntity> getAllSeries() throws SeriesServiceDatabaseException;
+
+  /**
+   * Returns all series (including deleted ones!) that have been modified in the
+   * given date range {@code from} (inclusive) -- {@code to} (exclusive). At
+   * most {@code limit} many series are returned. ACLs/permissions are NOT
+   * checked as this is only intended to be used in an administrative context.
+   */
+  List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesServiceDatabaseException;
 
   /**
    * Retrieves ACL for series with given ID.

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -50,6 +50,7 @@ import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.util.SecurityUtil;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesQuery;
 import org.opencastproject.series.api.SeriesService;
@@ -75,6 +76,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -362,6 +364,22 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       throw new SeriesException(e);
     }
   }
+
+  @Override
+  public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesException {
+    try {
+      return persistence.getAllForAdministrativeRead(from, to, limit);
+    } catch (SeriesServiceDatabaseException e) {
+      String msg = String.format(
+          "Exception while reading all series in range %s to %s from persistence storage",
+          from,
+          to
+      );
+      throw new SeriesException(msg, e);
+    }
+  }
+
 
   @Override
   public Map<String, String> getIdTitleMapOfAllSeries() throws SeriesException, UnauthorizedException {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -36,6 +36,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapKeyColumn;
@@ -55,7 +56,11 @@ import javax.persistence.UniqueConstraint;
 @Entity(name = "SeriesEntity")
 @IdClass(SeriesEntityId.class)
 @Access(AccessType.FIELD)
-@Table(name = "oc_series")
+@Table(name = "oc_series",
+    indexes = {
+        @Index(name = "IX_oc_series_modified_date", columnList = ("modified_date")),
+    }
+)
 @NamedQueries({
     @NamedQuery(
         name = "Series.findAll",

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -52,7 +52,8 @@ import javax.persistence.UniqueConstraint;
  * rules.
  *
  */
-@Entity(name = "SeriesEntity") @IdClass(SeriesEntityId.class)
+@Entity(name = "SeriesEntity")
+@IdClass(SeriesEntityId.class)
 @Access(AccessType.FIELD)
 @Table(name = "oc_series")
 @NamedQueries({
@@ -67,6 +68,18 @@ import javax.persistence.UniqueConstraint;
     @NamedQuery(
         name = "seriesById",
         query = "select s from SeriesEntity as s where s.seriesId=:seriesId and s.organization=:organization"
+    ),
+    @NamedQuery(
+        name = "Series.getAllModifiedSince",
+        query = "select s from SeriesEntity as s "
+            + "where s.modifiedDate >= :since "
+            + "order by s.modifiedDate asc"
+    ),
+    @NamedQuery(
+        name = "Series.getAllModifiedInRange",
+        query = "select s from SeriesEntity as s "
+            + "where s.modifiedDate >= :from and s.modifiedDate < :to "
+            + "order by s.modifiedDate asc"
     ),
 })
 public class SeriesEntity {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -22,6 +22,7 @@
 package org.opencastproject.series.impl.persistence;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -41,6 +42,8 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -53,13 +56,18 @@ import javax.persistence.UniqueConstraint;
 @Access(AccessType.FIELD)
 @Table(name = "oc_series")
 @NamedQueries({
-    @NamedQuery(name = "Series.findAll", query = "select s from SeriesEntity s"),
-    @NamedQuery(name = "Series.getCount", query = "select COUNT(s) from SeriesEntity s"),
+    @NamedQuery(
+        name = "Series.findAll",
+        query = "select s from SeriesEntity s where s.deletionDate is null"
+    ),
+    @NamedQuery(
+        name = "Series.getCount",
+        query = "select COUNT(s) from SeriesEntity s where s.deletionDate is null"
+    ),
     @NamedQuery(
         name = "seriesById",
         query = "select s from SeriesEntity as s where s.seriesId=:seriesId and s.organization=:organization"
     ),
-    @NamedQuery(name = "allSeriesInOrg", query = "select s from SeriesEntity as s where s.organization=:organization")
 })
 public class SeriesEntity {
 
@@ -83,6 +91,14 @@ public class SeriesEntity {
   @Lob
   @Column(name = "access_control", length = 65535)
   protected String accessControl;
+
+  @Column(name = "modified_date")
+  @Temporal(TemporalType.TIMESTAMP)
+  protected Date modifiedDate = new Date();
+
+  @Column(name = "deletion_date")
+  @Temporal(TemporalType.TIMESTAMP)
+  protected Date deletionDate = null;
 
   @Lob
   @ElementCollection(targetClass = String.class)
@@ -186,6 +202,26 @@ public class SeriesEntity {
    */
   public void setOrganization(String organization) {
     this.organization = organization;
+  }
+
+  public Date getModifiedDate() {
+    return this.modifiedDate;
+  }
+
+  public void setModifiedDate(Date date) {
+    this.modifiedDate = date;
+  }
+
+  public Date getDeletionDate() {
+    return this.deletionDate;
+  }
+
+  public void setDeletionDate(Date date) {
+    this.deletionDate = date;
+  }
+
+  public boolean isDeleted() {
+    return this.deletionDate != null;
   }
 
   public Map<String, String> getProperties() {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -21,9 +21,12 @@
 
 package org.opencastproject.series.impl.persistence;
 
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
+import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AccessControlParsingException;
@@ -34,6 +37,7 @@ import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.impl.SeriesServiceDatabase;
 import org.opencastproject.series.impl.SeriesServiceDatabaseException;
 import org.opencastproject.util.NotFoundException;
@@ -52,15 +56,18 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 /**
  * Implements {@link SeriesServiceDatabase}. Defines permanent storage for series.
@@ -391,6 +398,61 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         tx.rollback();
       }
       throw new SeriesServiceDatabaseException(e);
+    } finally {
+      em.close();
+    }
+  }
+
+  @Override
+  public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesServiceDatabaseException {
+    // Validate parameters
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit has to be > 0");
+    }
+
+    // Make sure the user is actually an administrator of sorts
+    User user = securityService.getUser();
+    if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
+      throw new SeriesServiceDatabaseException(
+          new UnauthorizedException(user, getClass().getName() + ".getModifiedInRangeForAdministrativeRead")
+      );
+    }
+
+    // Load series from DB.
+    EntityManager em = emf.createEntityManager();
+    try {
+      TypedQuery<SeriesEntity> q;
+      if (to.isPresent()) {
+        if (from.after(to.get())) {
+          throw new IllegalArgumentException("`from` is after `to`");
+        }
+
+        q = em.createNamedQuery("Series.getAllModifiedInRange", SeriesEntity.class)
+            .setParameter("from", from)
+            .setParameter("to", to.get())
+            .setMaxResults(limit);
+      } else {
+        q = em.createNamedQuery("Series.getAllModifiedSince", SeriesEntity.class)
+            .setParameter("since", from)
+            .setMaxResults(limit);
+      }
+
+      final List<Series> out = new ArrayList<>();
+      for (SeriesEntity entity : q.getResultList()) {
+        final Series series = new Series();
+        series.setId(entity.getSeriesId());
+        series.setOrganization(entity.getOrganization());
+        series.setDublinCore(DublinCoreXmlFormat.read(entity.getDublinCoreXML()));
+        series.setModifiedDate(entity.getModifiedDate());
+        series.setDeletionDate(entity.getDeletionDate());
+        out.add(series);
+      }
+
+      return out;
+    } catch (Exception e) {
+      String msg = String.format("Could not retrieve series modified between '%s' and '%s'", from, to);
+      throw new SeriesServiceDatabaseException(msg, e);
     } finally {
       em.close();
     }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -174,7 +174,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete series: {}", e.getMessage());
+      logger.error("Could not delete series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -219,7 +219,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete series: {}", e.getMessage());
+      logger.error("Could not delete property for series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -242,7 +242,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     try {
       return query.getResultList();
     } catch (Exception e) {
-      logger.error("Could not retrieve all series: {}", e.getMessage());
+      logger.error("Could not retrieve all series", e);
       throw new SeriesServiceDatabaseException(e);
     } finally {
       em.close();
@@ -271,7 +271,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not retrieve ACL for series '{}': {}", seriesId, e.getMessage());
+      logger.error("Could not retrieve ACL for series '{}'", seriesId, e);
       throw new SeriesServiceDatabaseException(e);
     } finally {
       em.close();
@@ -329,7 +329,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
       tx.commit();
       return newSeries;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not update series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -373,7 +373,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -407,7 +407,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve properties of series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -445,7 +445,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve property '{}' of series '{}'", propertyName, seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -508,7 +508,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     try {
       serializedAC = AccessControlParser.toXml(accessControl);
     } catch (Exception e) {
-      logger.error("Could not serialize access control parameter: {}", e.getMessage());
+      logger.error("Could not serialize access control parameter", e);
       throw new SeriesServiceDatabaseException(e);
     }
     EntityManager em = emf.createEntityManager();
@@ -540,7 +540,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not store ACL for series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -169,7 +170,10 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
           throw new UnauthorizedException(currentUser + " is not authorized to update series " + seriesId);
         }
       }
-      em.remove(entity);
+
+      entity.setModifiedDate(new Date());
+      entity.setDeletionDate(new Date());
+      em.merge(entity);
       tx.commit();
     } catch (NotFoundException e) {
       throw e;
@@ -214,6 +218,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
 
       properties.remove(propertyName);
       entity.setProperties(properties);
+      entity.setModifiedDate(new Date());
       em.merge(entity);
       tx.commit();
     } catch (NotFoundException e) {
@@ -303,13 +308,20 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     DublinCoreCatalog newSeries = null;
     try {
       tx.begin();
-      SeriesEntity entity = getSeriesEntity(seriesId, em);
-      if (entity == null) {
+      SeriesEntity entity = getPotentiallyDeletedSeriesEntity(seriesId, em);
+      if (entity == null || entity.isDeleted()) {
+        // If the series existed but is marked deleted, we completely delete it
+        // here to make sure no remains of the old series linger.
+        if (entity != null) {
+          this.deleteSeries(seriesId);
+        }
+
         // no series stored, create new entity
         entity = new SeriesEntity();
         entity.setOrganization(securityService.getOrganization().getId());
         entity.setSeriesId(seriesId);
         entity.setSeries(seriesXML);
+        entity.setModifiedDate(new Date());
         em.persist(entity);
         newSeries = dc;
       } else {
@@ -324,6 +336,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
           }
         }
         entity.setSeries(seriesXML);
+        entity.setModifiedDate(new Date());
         em.merge(entity);
       }
       tx.commit();
@@ -373,7 +386,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not retrieve series", e);
+      logger.error("Could not retrieve series with ID '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -534,6 +547,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         updated = true;
       }
       entity.setAccessControl(serializedAC);
+      entity.setModifiedDate(new Date());
       em.merge(entity);
       tx.commit();
       return updated;
@@ -587,6 +601,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
       Map<String, String> properties = entity.getProperties();
       properties.put(propertyName, propertyValue);
       entity.setProperties(properties);
+      entity.setModifiedDate(new Date());
       em.merge(entity);
       tx.commit();
     } catch (NotFoundException e) {
@@ -611,9 +626,23 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
    *          the series identifier
    * @param em
    *          an open entity manager
-   * @return the series entity, or null if not found
+   * @return the series entity, or null if not found or if the series is deleted.
    */
   protected SeriesEntity getSeriesEntity(String id, EntityManager em) {
+    SeriesEntity entity = getPotentiallyDeletedSeriesEntity(id, em);
+    return entity == null || entity.isDeleted() ? null : entity;
+  }
+
+  /**
+   * Gets a potentially deleted series by its ID, using the current organizational context.
+   *
+   * @param id
+   *          the series identifier
+   * @param em
+   *          an open entity manager
+   * @return the series entity, or null if not found
+   */
+  protected SeriesEntity getPotentiallyDeletedSeriesEntity(String id, EntityManager em) {
     String orgId = securityService.getOrganization().getId();
     Query q = em.createNamedQuery("seriesById").setParameter("seriesId", id).setParameter("organization", orgId);
     try {
@@ -637,6 +666,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         success = false;
       } else {
         series.addElement(type, data);
+        series.setModifiedDate(new Date());
         em.merge(series);
         tx.commit();
         success = true;
@@ -669,6 +699,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
       } else {
         if (series.getElements().containsKey(type)) {
           series.removeElement(type);
+          series.setModifiedDate(new Date());
           em.merge(series);
           tx.commit();
           success = true;

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -42,6 +42,7 @@ import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesQuery;
 import org.opencastproject.series.api.SeriesService;
@@ -83,9 +84,11 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import javax.ws.rs.GET;
@@ -320,6 +323,13 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
       closeConnection(response);
     }
     throw new SeriesException("Unable to get series from remote series index");
+  }
+
+  @Override
+  public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesException {
+    // TODO: decide what to do about this.
+    throw new SeriesException("NOT IMPLEMENTED");
   }
 
   @Override

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -43,6 +43,16 @@
       <artifactId>opencast-search-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-dublincore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencastproject</groupId>
     <artifactId>base</artifactId>
-    <version>10-SNAPSHOT</version>
+    <version>11-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <properties>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
@@ -24,11 +24,15 @@ package org.opencastproject.tobira.impl;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_DESCRIPTION;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TITLE;
 import static org.opencastproject.util.doc.rest.RestParameter.Type;
 
 import org.opencastproject.search.api.SearchQuery;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchService;
+import org.opencastproject.series.api.Series;
+import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -42,8 +46,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
@@ -63,9 +71,28 @@ import javax.ws.rs.core.Response;
     notes = { "This provides API endpoint used by Tobira to harvest media metadata" }
 )
 public class TobiraApi {
+  /**
+   * A duration to allow some leeway for certain database operations to be slow.
+   *
+   * The correct usage of the harvesting API depends on the correct adjustment of the {@code since}
+   * parameter between different requests. If `since` is increased too much, some event/series
+   * modifications could be missed. One fact which makes this harder is that the modified date of
+   * events/series can be significantly lower/before the time those changes are written to the
+   * database or index. That's because the "now" timestamp is created in Java and written to the
+   * database afterwards. Unfortunately, we are not just talking about milliseconds, but up to many
+   * seconds. This can have different reasons, but since Opencast can be distributed, network plays
+   * a big role here.
+   *
+   * But to not completely give up on an incremental harvesting API, we define an arbitrary "buffer
+   * period". Writes that take longer (i.e. the time between `new Date()` and the serialization in
+   * the DB/index) than this buffer could lead to missed updates with this harvesting API.
+   */
+  private static final long TIME_BUFFER_SIZE = 3 * 60 * 1000;
+
   private static final Logger logger = LoggerFactory.getLogger(TobiraApi.class);
 
   private SearchService searchService;
+  private SeriesService seriesService;
 
   @Activate
   public void activate(BundleContext bundleContext) {
@@ -74,6 +101,10 @@ public class TobiraApi {
 
   public void setSearchService(SearchService service) {
     this.searchService = service;
+  }
+
+  public void setSeriesService(SeriesService service) {
+    this.seriesService = service;
   }
 
   @GET
@@ -123,59 +154,115 @@ public class TobiraApi {
     logger.debug("Request to '/harvest' with limit={} and since={}", limit, since);
 
     try {
+      // Retrieve episodes from index.
+      //
+      // We actually fetch `limit + 1` to get some useful extra information: whether there are more
+      // events and if so, what timestamp that extra event was modified at.
       final SearchQuery q = new SearchQuery()
           .withUpdatedSince(new Date(since))
           .withSort(SearchQuery.Sort.DATE_MODIFIED)
           .includeDeleted(true)
-          // We fetch one item more to know the timestamp of that item. See below how this is used.
           .withLimit(limit + 1);
-      final SearchResultItem[] results = searchService.getByQuery(q).getItems();
-      logger.debug("Retrieved {} events from the index during harvest", results.length);
+      final SearchResultItem[] rawEvents = searchService.getForAdministrativeRead(q).getItems();
+      final boolean hasMoreEvents = rawEvents.length == limit + 1;
+      logger.debug("Retrieved {} events from the index during harvest", rawEvents.length);
 
-      // Obtain information to allow Tobira to plan the next harvesting request. The `since`
-      // timestamp that needs to be used next is always the timestamp of the last item. In case we
-      // got `limit + 1` items, it's exactly the timestamp of the next new item. Otherwise, it's the
-      // timestamp of an item that Tobira already received. But Tobira has to be able to deal with
-      // duplicate items anyway.
-      boolean hasMore = results.length == limit + 1;
-      long includesItemsUntil = results.length > 0
-          ? results[results.length - 1].getModified().getTime()
-          : since; // TODO: this could maybe be `now()` or `now() - 5 min`
 
-      final ArrayList<Jsons.Val> items = Arrays.stream(results)
-          // We fetched up to `limit + 1` items above, so we limit here again to the actual number
-          // of items.
+      // Retrieve series from DB.
+      //
+      // Here we optimize a bit to avoid transfering some items twice. If the events were limited by
+      // `limit` (i.e. there are more than we will return), we only fetch series that were modified
+      // before the modification date of the last event we will return. Consider that
+      // `includesItemsUntil` can be at most that event's modification date. So if we were to now
+      // return any series that are modified after that timestamp, they will be returned by the
+      // next request of the client as well, since the next request's `since` parameter is the
+      // `includesItemsUntil` value of the current response.
+      //
+      // We also fetch `limit + 1` here to be able to know whether there are more series in the
+      // given time range, which allows us to figure out `hasMore` and `includesItemsUntil` more
+      // precisely.
+      final Optional<Date> seriesRangeEnd = hasMoreEvents
+          ? Optional.of(rawEvents[rawEvents.length - 2].getModified())
+          : Optional.empty();
+      final List<Series> rawSeries = seriesService.getAllForAdministrativeRead(
+          new Date(since),
+          seriesRangeEnd,
+          limit + 1
+      );
+      final boolean hasMoreSeriesInRange = rawSeries.size() == limit + 1;
+      logger.debug("Retrieved {} series from the database during harvest", rawSeries.size());
+
+
+      // Convert events and series into JSON representation. We limit both to `limit` here again,
+      // because we fetched `limit + 1` above.
+      final Stream<Item> eventItems = Arrays.stream(rawEvents)
           .limit(limit)
-          .map(item -> {
-            long modified = item.getModified().getTime();
-
-            // TODO: does `deleted != null` really imply the event is deleted?
-            if (item.getDeletionDate() == null) {
-              return Jsons.obj(
-                  Jsons.p("kind", "event"),
-                  Jsons.p("id", item.getId()),
-                  Jsons.p("title", item.getDcTitle()),
-                  Jsons.p("partOf", item.getDcIsPartOf()),
-                  Jsons.p("description", item.getDcDescription()),
-                  Jsons.p("updated", modified)
-              );
-            } else {
-              return Jsons.obj(
-                  Jsons.p("kind", "event-deleted"),
-                  Jsons.p("id", item.getId()),
-                  Jsons.p("updated", modified)
-              );
+          .filter(event -> {
+            // Here, we potentially filter out some events. Compare to above: when loading series
+            // from the DB, we used the modified date of the last event as upper bound of the series
+            // modified date. That is, IF we had more events than `limit`. The same reasoning
+            // applies the other way: if we have more series than `limit`, then all events with
+            // modified dates after the modified date of the last series we return will be included
+            // in the next request anyway. So we might as well filter them out here to save a bit
+            // on the size of this request.
+            //
+            // The reason we first filter series, then events, is because it is likely that an
+            // Opencast instance contains way more events than series. This means that
+            // `hasMoreSeriesInRange` being true is actually very uncommon.
+            if (!hasMoreSeriesInRange) {
+              return true;
             }
-          })
-          .collect(Collectors.toCollection(ArrayList::new));
 
-      // Assembly full response
+            final Date lastSeriesModifiedDate = rawSeries.get(rawSeries.size() - 2)
+                .getModifiedDate();
+            return !event.getModified().after(lastSeriesModifiedDate);
+          })
+          .map(event -> new Item(event));
+
+      final Stream<Item> seriesItems = rawSeries.stream()
+          .limit(limit)
+          .map(series -> new Item(series));
+
+
+      // Combine series and events into one combined list and sort it.
+      //
+      // The sorting is, again, not for correctness, because consumers of this API need to be
+      // able to deal with that. However, sorting this here will result in fewer temporary objects
+      // or invalid states in the consumer.
+      final ArrayList<Item> items = Stream.concat(eventItems, seriesItems)
+          .collect(Collectors.toCollection(ArrayList::new));
+      items.sort(Comparator.comparing(item -> item.getModifiedDate()));
+
+
+      // Obtain information to allow Tobira to plan the next harvesting request.
+      //
+      // The timestamp that can be used as next `since` parameter depends on whether we have more
+      // items. If that's not the case, we basically just return the current timestamp (minus a
+      // buffer, see docs for `TIME_BUFFER_SIZE`). If we have more items, we can use the timestamp
+      // of the last item in `items`, thanks to our filtering and upper limit on modified date
+      // above. However, it must also be at least `TIME_BUFFER_SIZE` in the past.
+      boolean hasMore = hasMoreEvents || hasMoreSeriesInRange;
+      final long timeBuffer = new Date().getTime() - TIME_BUFFER_SIZE;
+      final long includesItemsUntil = hasMore
+          ? Math.min(items.get(items.size() - 1).getModifiedDate().getTime(), timeBuffer)
+          : timeBuffer;
+
+
+      // Assembly full response.
+      final List<Jsons.Val> outItems = items.stream()
+          .map(item -> item.getJson())
+          .collect(Collectors.toCollection(ArrayList::new));
       final Jsons.Obj json = Jsons.obj(
           Jsons.p("includesItemsUntil", includesItemsUntil),
           Jsons.p("hasMore", hasMore),
-          Jsons.p("items", Jsons.arr(items))
+          Jsons.p("items", Jsons.arr(outItems))
       );
-      logger.debug("Returning {} items from harvesting (hasMore={})", items.size(), hasMore);
+      logger.debug(
+          "Returning {} items from harvesting (hasMore = {}, includesItemsUntil = {})",
+          items.size(),
+          hasMore,
+          new Date(includesItemsUntil)
+      );
 
       return Response.ok()
           .type(APPLICATION_JSON_TYPE)
@@ -191,5 +278,66 @@ public class TobiraApi {
   private static Response badRequest(String msg) {
     logger.warn("Bad request to tobira/harvest: {}", msg);
     return Response.status(BAD_REQUEST).entity(msg).build();
+  }
+
+
+  /**
+   * A item of the harvesting API, basically as a JSON object. Can be "event", "series",
+   * "event-deleted" or "series-deleted". Also contains the modified date, used for sorting.
+   */
+  private class Item {
+    private Date modifiedDate;
+    private Jsons.Val obj;
+
+    /** Converts a series into the corresponding JSON representation */
+    Item(SearchResultItem event) {
+      this.modifiedDate = event.getModified();
+
+      if (event.getDeletionDate() != null) {
+        this.obj = Jsons.obj(
+            Jsons.p("kind", "event-deleted"),
+            Jsons.p("id", event.getId()),
+            Jsons.p("updated", event.getModified().getTime())
+        );
+      } else {
+        this.obj = Jsons.obj(
+            Jsons.p("kind", "event"),
+            Jsons.p("id", event.getId()),
+            Jsons.p("title", event.getDcTitle()),
+            Jsons.p("partOf", event.getDcIsPartOf()),
+            Jsons.p("description", event.getDcDescription()),
+            Jsons.p("updated", event.getModified().getTime())
+        );
+      }
+    }
+
+    /** Converts a series into the corresponding JSON representation */
+    Item(Series series) {
+      this.modifiedDate = series.getModifiedDate();
+
+      if (series.isDeleted()) {
+        this.obj = Jsons.obj(
+          Jsons.p("kind", "series-deleted"),
+          Jsons.p("id", series.getId()),
+          Jsons.p("modified", series.getModifiedDate().getTime())
+        );
+      } else {
+        this.obj = Jsons.obj(
+          Jsons.p("kind", "series"),
+          Jsons.p("id", series.getId()),
+          Jsons.p("title", series.getDublinCore().getFirst(PROPERTY_TITLE)),
+          Jsons.p("description", series.getDublinCore().getFirst(PROPERTY_DESCRIPTION)),
+          Jsons.p("modified", series.getModifiedDate().getTime())
+        );
+      }
+    }
+
+    Date getModifiedDate() {
+      return this.modifiedDate;
+    }
+
+    Jsons.Val getJson() {
+      return this.obj;
+    }
   }
 }

--- a/modules/tobira/src/main/resources/OSGI-INF/tobira-api.xml
+++ b/modules/tobira/src/main/resources/OSGI-INF/tobira-api.xml
@@ -13,4 +13,7 @@
     <reference name="searchService"
                interface="org.opencastproject.search.api.SearchService"
                bind="setSearchService"/>
+    <reference name="seriesService"
+               interface="org.opencastproject.series.api.SeriesService"
+               bind="setSeriesService"/>
 </scr:component>


### PR DESCRIPTION
Also see commit messages. Main open questions:

- Is the addition to the `SeriesSerivce` (and related stuff) ok like this? Will this be accepted in the community?
- ~~Do I really need to implement that method for the remote impl? Like... can we just say Tobira is only on the admin? Or sth like that?~~ We decided for now that we will just throw an exception and care about this later. 
- Are you happy with the new code and logic in the Tobira module?

The only things left, as far as I can tell, before calling this initial API finished:
- [ ] Adding good REST docs to it
- [ ] Adding more fields to the reply. Currently, hardly any useful information is given for event and series. That has to be more. But adding that should be very straight forward.
- [x] Renaming and correctly describing the `limit` parameter to clarify it's just a guideline and the API can return however many.
- [ ] DB migrations
- [ ] Index for `deletion_date`?