### PR TITLE
No concurrent deployments

### DIFF
--- a/.github/workflows/deploy-tobira-opencast.yml
+++ b/.github/workflows/deploy-tobira-opencast.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: global
+  cancel-in-progress: false
+
 jobs:
   build:
     name: deploy tobira opencast


### PR DESCRIPTION
This patch allows just one deployment process to run at a time to not
accidentally start Opencast while someone else is deleting Opencast.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
