### PR TITLE
Fix publication of language tagged metadata

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -27,7 +27,6 @@ import static org.opencastproject.security.api.Permissions.Action.WRITE;
 import static org.opencastproject.util.RequireUtil.notNull;
 import static org.opencastproject.util.data.Collections.flatMap;
 import static org.opencastproject.util.data.Collections.head;
-import static org.opencastproject.util.data.Collections.map;
 import static org.opencastproject.util.data.Option.option;
 
 import org.opencastproject.mediapackage.Attachment;
@@ -104,6 +103,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Utility class used to manage the search index.
@@ -681,21 +681,15 @@ public class SolrIndexManager {
   }
 
   static List<DField<String>> fromMValue(List<MetadataValue<String>> as) {
-    return map(as, new ArrayList<DField<String>>(), new Function<MetadataValue<String>, DField<String>>() {
-      @Override
-      public DField<String> apply(MetadataValue<String> v) {
-        return new DField<String>(v.getValue(), v.getLanguage());
-      }
-    });
+    return as.stream()
+        .map(v -> new DField<>(v.getValue(), ""))
+        .collect(Collectors.toList());
   }
 
   static List<DField<String>> fromDCValue(List<DublinCoreValue> as) {
-    return map(as, new ArrayList<DField<String>>(), new Function<DublinCoreValue, DField<String>>() {
-      @Override
-      public DField<String> apply(DublinCoreValue v) {
-        return new DField<String>(v.getValue(), v.getLanguage());
-      }
-    });
+    return as.stream()
+        .map(v -> new DField<>(v.getValue(), ""))
+        .collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
This patch fixes the publication of language tagged metadata to the
search service's Solr index which would previously fail and cause an
inconsistent state so that you couldn't even retract/delete the data any
longer.

More details:

Opencast once had the idea to support metadata in several languages at
once, so that users could e.g. specify an English, a Spanish and a
German title in the Dublin Core catalog.

Such metadata would look like this:

```xml
<dcterms:contributor>Department of Materials</dcterms:contributor>
<dcterms:contributor xml:lang="en">Department of Materials</dcterms:contributor>
<dcterms:contributor xml:lang="de">Fakultät Materialwissenschaften</dcterms:contributor>
```

This is still supported by Opencast internally, although no user
interface supports specifying this.

Opencast will use this to build a Solr document with fields like this:

```
dc_contributor___=dc_contributor___(2.0)={Department of Materials},
```

The Solr schema allows this to be a dynamic single-value field on which
other fields depend:

```xml
<dynamicField name="dc_contributor_*" type="text" indexed="true" stored="true" omitNorms="true"/>
<field name="dc_contributor-sort" type="string" indexed="true" stored="false" multiValued="false" />
<copyField source="dc_contributor_*" dest="dc_contributor-sort"/>
```

Without language tags this works kind of fine since a second contributor
will overwrite the first contributor and that is what is then used in
the `dc_contributor-sort` field. Overwriting previous contributors means
that you loose the ability to search for these in those fields, but at
least things work apart from that bug.

Unfortunately, once language tags are used, the fields will become
something like this:

```
dc_contributor___=dc_contributor___(2.0)={Department of Materials},
dc_contributor_en=dc_contributor_en(2.0)={Department of Materials},
```

This causes Solr to try to copy multiple values into a single value
fields, causing the whole process to break with an exception.

Since language tagged metadata are more or less a relict from the past,
this patch ignores them and assures they are treated exactly as non
tagged metadata, making the whole process work again.

This patch furthermore ignores the bug of metadata values overwriting
each other since fixing that would cause a index rebuild which doesn't
seem sensible when we are likely about to replace the whole index soon.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
