### PR TITLE
Use `Jsons.NULL` instead of `null` for missing resolution

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
@@ -336,7 +336,7 @@ public class TobiraApi {
         final List<Jsons.Val> tracks = Arrays.stream(event.getMediaPackage().getTracks())
             .map(track -> {
               VideoStream[] videoStreams = TrackSupport.byType(track.getStreams(), VideoStream.class);
-              Jsons.Val resolution = null;
+              Jsons.Val resolution = Jsons.NULL;
               if (videoStreams.length > 0) {
                 final VideoStream stream = videoStreams[0];
                 resolution = Jsons.arr(Jsons.v(stream.getFrameWidth()), Jsons.v(stream.getFrameHeight()));


### PR DESCRIPTION
Previously, this would lead to a null exception. The reason we can pass
`null` for many other fields is because there, the `Jsons.p` overload
for strings or whatever is used, which accepts `null`. But the `Jsons.p`
overload for `Jsons.Val` does not.
