### PR TITLE
Add event ACLs to harvest response

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItem.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItem.java
@@ -23,6 +23,7 @@
 package org.opencastproject.search.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.AccessControlList;
 
 import java.util.Date;
 
@@ -58,6 +59,11 @@ public interface SearchResultItem {
    * @return the organization identifier
    */
   String getOrganization();
+
+  /**
+   * Returns the access control list of this event that is stored in the index.
+   */
+  AccessControlList getAccessControlList();
 
   /**
    * @return the dcExtent

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItemImpl.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItemImpl.java
@@ -23,6 +23,7 @@
 package org.opencastproject.search.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.AccessControlList;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -62,6 +63,9 @@ public class SearchResultItemImpl implements SearchResultItem {
   /** The media package */
   @XmlElement(name = "mediapackage", namespace = "http://mediapackage.opencastproject.org")
   private MediaPackage mediaPackage = null;
+
+  @XmlElement(name = "acl")
+  private AccessControlList acl = null;
 
   /** Dublin core field 'dc:extent' */
   @XmlElement
@@ -595,6 +599,14 @@ public class SearchResultItemImpl implements SearchResultItem {
     return mediaPackage;
   }
 
+  public void setAccessControlList(AccessControlList acl) {
+    this.acl = acl;
+  }
+
+  public AccessControlList getAccessControlList() {
+    return acl;
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -708,6 +720,7 @@ public class SearchResultItemImpl implements SearchResultItem {
     item.setId(from.getId());
     item.setOrganization(from.getOrganization());
     item.setMediaPackage(from.getMediaPackage());
+    item.setAccessControlList(from.getAccessControlList());
     item.setDcExtent(from.getDcExtent());
     item.setDcTitle(from.getDcTitle());
     item.setDcSubject(from.getDcSubject());

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
@@ -35,6 +35,7 @@ import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultImpl;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchResultItemImpl;
+import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.util.data.Function;
 
 import com.google.common.cache.CacheBuilder;
@@ -242,6 +243,11 @@ public class SeriesFeedService extends AbstractFeedService implements FeedGenera
 
           @Override
           public MediaPackage getMediaPackage() {
+            return null;
+          }
+
+          @Override
+          public AccessControlList getAccessControlList() {
             return null;
           }
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -725,8 +725,9 @@ public class SolrIndexManager {
         actionPermissions = new ArrayList<String>();
         permissions.put(entry.getAction(), actionPermissions);
       }
-      actionPermissions.add(entry.getRole());
-
+      if (adminRole != null && !entry.getRole().equals(adminRole)) {
+        actionPermissions.add(entry.getRole());
+      }
     }
 
     // Write the permissions to the solr document

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -721,10 +721,6 @@ public class SolrIndexManager {
         logger.debug("Search service doesn't know how to handle action: {}", entry.getAction());
         continue;
       }
-      if (acl == null) {
-        actionPermissions = new ArrayList<String>();
-        permissions.put(entry.getAction(), actionPermissions);
-      }
       if (adminRole != null && !entry.getRole().equals(adminRole)) {
         actionPermissions.add(entry.getRole());
       }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -40,6 +40,8 @@ import org.opencastproject.search.api.SearchResultImpl;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchResultItem.SearchResultItemType;
 import org.opencastproject.search.api.SearchResultItemImpl;
+import org.opencastproject.security.api.AccessControlEntry;
+import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
@@ -62,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
@@ -69,6 +72,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Class implementing <code>LookupRequester</code> to provide connection to solr indexing facility.
@@ -207,6 +211,18 @@ public class SolrRequester {
             }
           }
           return null;
+        }
+
+        @Override
+        public AccessControlList getAccessControlList() {
+          final List<AccessControlEntry> entries = Schema.getOcAcl(doc)
+              .stream()
+              .flatMap(field -> {
+                return Arrays.stream(field.getValue().strip().split("\\s+"))
+                    .map(role -> new AccessControlEntry(role, field.getSuffix(), true));
+              })
+              .collect(Collectors.toCollection(ArrayList::new));
+          return new AccessControlList(entries);
         }
 
         @Override


### PR DESCRIPTION
We certainly need that on Tobira site at some point. This PR only adds event ACLs as series ACLs are basically just templates and Opencast itself does not restrict "series access in itself" anyway.

Unfortunately, the `SearchResultItem` did not offer access to ACLs yet, so I needed to add that. There are two TODOs in the code that I'm not unsure about. I'm also not 100% comfortable with splitting the index value by whitespace and using the result as roles, but it's probably fine?