### PR TITLE
Disable static file authorization for test OC instance

### DIFF
--- a/.deployment/roles/opencast/tasks/main.yml
+++ b/.deployment/roles/opencast/tasks/main.yml
@@ -79,6 +79,7 @@
     mode: '0644'
   loop:
     - etc/custom.properties
+    - etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
     - bin/setenv
 
 - name: start and enable opencast service

--- a/.deployment/roles/opencast/templates/etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
+++ b/.deployment/roles/opencast/templates/etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
@@ -1,0 +1,10 @@
+# Shall the static file server check authorization?
+# You might want to disable this if you use other means of checking authentication like authentication tokens.
+# Default: true
+authentication.required = false
+
+# Makes the static file service check authentication and availability but return an X-Accel-Redirect header using the
+# following path prefix instead of serving the actual file.
+# More details: https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/
+# Default: null
+#x.accel.redirect = /protected


### PR DESCRIPTION
Tobira just uses links to Opencast files. Users authenticate against
Tobira and not Opencast. So all requests to static Opencast files are
unauthenticated.