### PR TITLE
Add timeline preview image and all additional metadata to harvest response

### DIFF
--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -23,6 +23,15 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -27,6 +27,7 @@ import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
+import org.opencastproject.workspace.api.Workspace;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +70,8 @@ final class Harvest {
       int preferredAmount,
       Date since,
       SearchService searchService,
-      SeriesService seriesService
+      SeriesService seriesService,
+      Workspace workspace
   ) throws UnauthorizedException, SeriesException {
     // Retrieve episodes from index.
     //
@@ -133,7 +135,7 @@ final class Harvest {
           final var lastSeriesModifiedDate = rawSeries.get(rawSeries.size() - 1).getModifiedDate();
           return !event.getModified().after(lastSeriesModifiedDate);
         })
-        .map(event -> new Item(event));
+        .map(event -> new Item(event, workspace));
 
     final var seriesItems = rawSeries.stream()
         .limit(preferredAmount)

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -134,7 +134,7 @@ class Item {
       this.obj = Jsons.obj(
           Jsons.p("kind", "event"),
           Jsons.p("id", event.getId()),
-          Jsons.p("title", event.getDcTitle()),
+          Jsons.p("title", mp.getTitle()),
           Jsons.p("partOf", event.getDcIsPartOf()),
           Jsons.p("description", event.getDcDescription()),
           Jsons.p("created", event.getDcCreated().getTime()),

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraApi.java
@@ -32,6 +32,7 @@ import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
+import org.opencastproject.workspace.api.Workspace;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -62,6 +63,7 @@ public class TobiraApi {
 
   private SearchService searchService;
   private SeriesService seriesService;
+  private Workspace workspace;
 
   @Activate
   public void activate(BundleContext bundleContext) {
@@ -74,6 +76,10 @@ public class TobiraApi {
 
   public void setSeriesService(SeriesService service) {
     this.seriesService = service;
+  }
+
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
   }
 
   @GET
@@ -128,7 +134,7 @@ public class TobiraApi {
 
     try {
       var json = Harvest.harvest(
-          preferredAmount, new Date(since), searchService, seriesService);
+          preferredAmount, new Date(since), searchService, seriesService, workspace);
 
       return Response.ok()
           .type(APPLICATION_JSON_TYPE)

--- a/modules/tobira/src/main/resources/OSGI-INF/tobira-api.xml
+++ b/modules/tobira/src/main/resources/OSGI-INF/tobira-api.xml
@@ -16,4 +16,7 @@
     <reference name="seriesService"
                interface="org.opencastproject.series.api.SeriesService"
                bind="setSeriesService"/>
+    <reference name="workspace"
+               interface="org.opencastproject.workspace.api.Workspace"
+               bind="setWorkspace"/>
 </scr:component>


### PR DESCRIPTION
This PR does mainly two things:

- All metadata (from the dublin core catalog) is included in a new `metadata` field. We filter out some fields that are already dealt with in a special way, e.g. title. So the `metadata` object only contains everything else.

- A new `timelinePreview` contains an object describing the url and layout of a timeline preview image. 

Note: with this, we now load a dublin core catalog. To be honest, I'm not 100% sure what this does, but if it loads the XML file from disk (or network) and parses it, this could make harvesting notably slower, unfortunately. I have not tested it yet, but we will see after merging. 