### PR TITLE
Include all catalogs for event metadata in Tobira harvest API

### DIFF
--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -28,10 +28,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.entwinemedia.common</groupId>
-      <artifactId>functional</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>


### PR DESCRIPTION
With this, extended metadata is also exposed in the Tobira API.