### PR TITLE
Add speech-to-text workflow

### DIFF
--- a/.deployment/roles/opencast/templates/etc/workflows/schedule-and-upload.xml
+++ b/.deployment/roles/opencast/templates/etc/workflows/schedule-and-upload.xml
@@ -111,6 +111,20 @@
       </configurations>
     </operation>
 
+    <!-- Generate captions -->
+
+    <operation
+      id="speechtotext"
+      description="Generates subtitles for video and audio files, derive language-code from metadata"
+      fail-on-error="false">
+      <configurations>
+        <configuration key="source-flavor">*/source</configuration>
+        <configuration key="target-flavor">captions/vtt+#{lang}</configuration>
+        <configuration key="target-element">attachment</configuration>
+        <configuration key="target-tags">archive,subtitle,engage-download</configuration>
+      </configurations>
+    </operation>
+
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Tag for review and cutting                                        -->
     <!--                                                                   -->


### PR DESCRIPTION
Workflow allows failures, i.e. schedule-and-upload won't fail if speech-to-text does (which happens when there is no audio or speech in a video).